### PR TITLE
Positions of menu elements adjusted.

### DIFF
--- a/components/gn-ui-menu.html
+++ b/components/gn-ui-menu.html
@@ -32,8 +32,9 @@
   <template>
     <paper-card id="menu">
       <div class="card-content">
-        <paper-input label="From"></paper-input>
         <div>
+          <paper-input label="From"></paper-input>
+          <!-- Stopovers are added here -->
           <template is="dom-repeat" items="{{intermediateobjects}}">
             <paper-input label="{{item.name}}" value="{{item.object}}">
               <div suffix></div>
@@ -43,11 +44,12 @@
           <paper-input label="To"></paper-input>
         </div>
         <div id="submenu">
-          <!-- Vehicle -->
+          <!-- Add Stopovers -->
           <div>
-          <paper-icon-button icon="icons:add" on-click="addStopover"></paper-icon-button>
-          <span>Add Stopovers</span>
+            <paper-icon-button icon="icons:add" on-click="addStopover"></paper-icon-button>
+            <span>Add Stopovers</span>
           </div>
+          <!-- Vehicle -->
           <paper-dropdown-menu label="Vehicle">
             <paper-listbox class="dropdown-content">
               <paper-item>Car-1</paper-item>
@@ -64,7 +66,6 @@
                 error-message="Must be a percentage"
                 value="{{ battery }}"><div suffix>%</div>
           </paper-input>
-          <!-- Add Stopovers -->
         </div>
       </div>
       <div class="card-actions">

--- a/components/gn-ui-menu.html
+++ b/components/gn-ui-menu.html
@@ -33,8 +33,21 @@
     <paper-card id="menu">
       <div class="card-content">
         <paper-input label="From"></paper-input>
+        <div>
+          <template is="dom-repeat" items="{{intermediateobjects}}">
+            <paper-input label="{{item.name}}" value="{{item.object}}">
+              <div suffix></div>
+              <paper-icon-button suffix value="{{index}}" icon="icons:delete" on-click="removeStopover"></paper-icon-button>
+            </paper-input>
+          </template>
+          <paper-input label="To"></paper-input>
+        </div>
         <div id="submenu">
           <!-- Vehicle -->
+          <div>
+          <paper-icon-button icon="icons:add" on-click="addStopover"></paper-icon-button>
+          <span>Add Stopovers</span>
+          </div>
           <paper-dropdown-menu label="Vehicle">
             <paper-listbox class="dropdown-content">
               <paper-item>Car-1</paper-item>
@@ -52,18 +65,7 @@
                 value="{{ battery }}"><div suffix>%</div>
           </paper-input>
           <!-- Add Stopovers -->
-          <paper-icon-button icon="icons:add" on-click="addStopover"></paper-icon-button>
-          <span>Add Stopovers</span>
         </div>
-        <div>
-          <template is="dom-repeat" items="{{intermediateobjects}}">
-            <paper-input label="{{item.name}}" value="{{item.object}}">
-              <div suffix></div>
-              <paper-icon-button suffix value="{{index}}" icon="icons:delete" on-click="removeStopover"></paper-icon-button>
-            </paper-input>
-          </template>
-        </div>
-        <paper-input label="To"></paper-input>
       </div>
       <div class="card-actions">
         <paper-icon-button icon="arrow-drop-down" id="toggleButton" on-click="toggleSubmenu"></paper-icon-button>


### PR DESCRIPTION
 `Vehicles` and `battery state` pushed at the bottom, `from` at the top, then `stopovers` and then `to`.

@fabianbormann, how about this alignment of menu elements?