### PR TITLE
Fix for issue #40: Grammatical error and no need for JSON.stringify(mapType)

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     }
   </style>
   <template id="app" is="dom-bind">
-    <p>Seledcted is {{JSON.stringify(mapType)}}</p>
+    <p>Selected is {{mapType}}</p>
     <gn-api route="{{ route }}" range="{{ range }}"></gn-api>
     <paper-drawer-panel id="drawer" force-narrow="true">
       <paper-header-panel drawer>


### PR DESCRIPTION
#40 
Corrected wrong spelling of "select" and removed call to JSON.stringify as it throws an error when called from within the mustache ({{}})