### PR TITLE
call getVehicles

### DIFF
--- a/components/gn-ui-menu.html
+++ b/components/gn-ui-menu.html
@@ -108,7 +108,9 @@
          */
         vehicles: {
           type: Array,
-          notify: true
+          value: function() {
+            return [];
+          }
         },
 
         /**
@@ -143,6 +145,12 @@
           value: 100,
           observer: '_positionChanged'
         }
+      },
+
+      attached: function() {
+        this.async(function() {
+          this.vehicles = document.querySelector('gn-api').getVehicles();
+        });
       },
 
       /**

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     }
   </style>
   <template id="app" is="dom-bind">
-    <gn-api route="{{ route }}" range="{{ range }}" vehicles={{vehicles}}></gn-api>
+    <gn-api route="{{ route }}" range="{{ range }}"></gn-api>
     <paper-drawer-panel id="drawer" force-narrow="true">
       <paper-header-panel drawer>
         <paper-toolbar>
@@ -73,7 +73,7 @@
           </paper-radio-group>
         </paper-toolbar>
         <div class="vertical layout">
-          <gn-ui-menu vehicles={{vehicles}} left="{{menuPositionLeft}}"></gn-ui-menu>
+          <gn-ui-menu left="{{menuPositionLeft}}"></gn-ui-menu>
           <gn-map class="flex"
             longitude="11.15"
             latitude="48.12"


### PR DESCRIPTION
Call `getVehicles` asynchronously and let `gn-ui-menu` set `this.vehicles` itself instead of `gn-api` setting the value in https://github.com/Greennav/webapp/blob/master/index.html#L51 and then passing in https://github.com/Greennav/webapp/blob/master/index.html#L76 to `gn-ui-menu`

Changes in `gn-api` corresponding to these changes are at [gn-api #7](https://github.com/Greennav/gn-api/pull/7)